### PR TITLE
reserves space for modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,12 @@ on:
     branches:
       - main
       - dev
+      - test
   push:
     branches:
       - main
       - dev
+      - test
   workflow_dispatch:
 
 jobs:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.manager
 Type: Package
 Title: DaVinci Module Manager
-Version: 2.1.6-9000
+Version: 2.1.7-9000
 Authors@R: c(person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
     person('Luis', 'Morís Fernández', email = 'luis.moris.fernandez@gmail.com', role = c('cre', 'aut')),
     person('Sorin', 'Voicu', email = 'sorin.voicu.ext@boehringer-ingelheim.com', role = c('aut')))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
-# dv.manager 2.1.6-9000
+# dv.manager 2.1.7-9000
 
 - Includes a new blockly filter in development mode
 - Updates old documentation
 - De-exports several util functions
+- Fixes tab group menu rendering
 
 
 # dv.manager 2.1.5

--- a/R/tab_group.R
+++ b/R/tab_group.R
@@ -255,7 +255,10 @@ compose_ui <- function(nh, ui_fn_list, ns) {
     res <- shiny::tabPanel(
       title = ui_fn_list[[nh]][["module_label"]],
       value = ui_fn_list[[nh]][["module_id"]],
-      ns_css(ui_fn_list[[nh]][["ui"]](ns(ui_fn_list[[nh]][["module_id"]])))
+      shiny::div(
+        class = "min-height-50-vh", # Force so tippy top menus fit into the screen
+        ns_css(ui_fn_list[[nh]][["ui"]](ns(ui_fn_list[[nh]][["module_id"]])))
+      )
     )
   } else {
     stop("Unknown Case")

--- a/inst/www/css/custom.scss
+++ b/inst/www/css/custom.scss
@@ -107,6 +107,10 @@ body > .container-fluid > .tabbable {
   overflow: hidden;
 }
 
+.min-height-50-vh {
+  min-height: 50vh;
+}
+
 .sidebar {
   width: $sidebar-width-open;
   height: 100vh;


### PR DESCRIPTION
# Hotfix checklist
 
- [x] Bumped minor version number on both DESCRIPTION and NEWS.md
 
- [x] Build passes pipeline checks
 
- [x] The new changes do not affect the API
 
- [x] The new changes do not affect the documentation (including screenshots)
 
- [x] The new changes do not impact the QC report

Tippy topper menus are drawn inside the parent element. Some modules do not reserve space by themselves, therefore menus are not properly drawn. We reserve a minimum 50vh for the modules.
This is not a perfect fix but should cover most of the cases.